### PR TITLE
Fix: patch lexical scoping for __builtin_reset.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ code/
 remote_includes/
 *.dSYM/
 *.txt
+*.pie

--- a/Interp/Interpreter.hxx
+++ b/Interp/Interpreter.hxx
@@ -3787,9 +3787,13 @@ struct Visitor {
     }
 
     void removeVar(const std::string& name) {
-        for(auto& curr_env : env) curr_env.first.erase(name);
+        for(auto& curr_env : std::views::reverse(env)) {
+            if (curr_env.first.contains(name)) {
+                curr_env.first.erase(name);
+                return;
+            }
+        }
     }
-
 
     Environment envStackToEnvMap() const {
         Environment e;

--- a/Tests/Test.cc
+++ b/Tests/Test.cc
@@ -8,6 +8,49 @@
 
 
 
+TEST_CASE("Lexical Scoping - Invalid Builtin Reset", "[Func][Builtin]") {
+    const auto src1 = R"(
+print = __builtin_print;
+
+.: f(a, 1) = "bye";
+
+func = () => {
+    .: f(a, 1) = "hi";
+
+    .: Should this reset clear the f right above / the top f?
+    __builtin_reset(f(a, 1));
+};
+
+f2 = () => {
+    f(a, 1) = 69;
+    func();
+};
+
+f2();
+.: print(f(a, 1));
+)";
+
+    REQUIRE_THROWS_AS(pie::test::run(src1), pie::except::NameLookup);
+}
+
+TEST_CASE("Lexical Scoping - Builtin Reset", "[Func][Builtin]") {
+    const auto src1 = R"(
+print = __builtin_print;
+f(a, 1) = "bye";
+
+func = () => {
+    f(a, 1) = "hi";
+
+    .: Should this reset clear the f right above / the top f?
+    __builtin_reset(f(a, 1));
+};
+
+func();
+print(f(a, 1));
+)";
+
+    REQUIRE(pie::test::run(src1) == "bye");
+}
 
 TEST_CASE("Operator Precedence", "[Operator][Prec]") {
     const auto src1 = R"(
@@ -2288,4 +2331,3 @@ print(add(g = 7, 1, c = 3, 2, 4, 5, f = 6, 1, "", 1.0));
 
     REQUIRE(pie::test::run(src) == "0");
 }
-


### PR DESCRIPTION
Purpose: Patch dynamic scoping bug for __builtin_reset for later.

Changes:
 - Ignore Pie snippets from Git, .gitignore updated with `*.pie`
 - Patch removeVar in `Interpreter.ixx`, deletes the most recent binding of a name a la dynamic scoping.
 - Added positive and negative test cases in `Test.cc`.

Let me know if there's more I can check out. Thanks 😄 